### PR TITLE
Add limits and resources to deployment

### DIFF
--- a/kube-ao-deployment.yaml
+++ b/kube-ao-deployment.yaml
@@ -25,6 +25,14 @@ spec:
       containers:
         - name: kube-ao
           image: 'appoptics/kube-ao:v0.1'
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           volumeMounts:
             - name: kube-ao-config
               readOnly: true


### PR DESCRIPTION
Add limits and resources to deployment to make sure pod has enough resources at all times.

This has been running for us for multiple weeks without issue now and should resolve Issue https://github.com/appoptics/kube-ao/issues/2